### PR TITLE
(PC-4943) update dependencies : add support for android 11.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,5 +142,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.3.1'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.3.2'
 }


### PR DESCRIPTION
## Fix

Mise à jour de la dépendance `androidbrowserhelper`, voir ce [changelog](https://github.com/GoogleChrome/android-browser-helper/releases) 

> 1.3.2
> @andreban andreban released this on 23 Jul · 71 commits to master since this release
>
> Updated Chrome OS support
> Support for Android 11